### PR TITLE
Redirect old docs to new docs site

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -5,6 +5,37 @@ const { themes } = require('prism-react-renderer');
 const lightTheme = themes.github;
 const darkTheme = themes.dracula;
 const isGithubPagesEnv = process.env.GITHUB_PAGES_ENV === 'true';
+const newDocsUrl = 'https://fleetbase.io/docs';
+
+function redirectToNewDocsPlugin() {
+    return {
+        name: 'redirect-to-new-docs',
+        injectHtmlTags() {
+            return {
+                headTags: [
+                    {
+                        tagName: 'meta',
+                        attributes: {
+                            'http-equiv': 'refresh',
+                            content: `0;url=${newDocsUrl}`,
+                        },
+                    },
+                    {
+                        tagName: 'link',
+                        attributes: {
+                            rel: 'canonical',
+                            href: newDocsUrl,
+                        },
+                    },
+                    {
+                        tagName: 'script',
+                        innerHTML: `window.location.replace('${newDocsUrl}');`,
+                    },
+                ],
+            };
+        },
+    };
+}
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -58,6 +89,7 @@ const config = {
     ],
 
     plugins: [
+        redirectToNewDocsPlugin,
         'docusaurus-plugin-image-zoom',
         [
             '@scalar/docusaurus',


### PR DESCRIPTION
## Summary
- Adds a Docusaurus HTML injection plugin that redirects every old docs page to https://fleetbase.io/docs.
- Includes a zero-second meta refresh, canonical URL, and JavaScript location replacement so old deep links leave the deprecated docs immediately.

## Verification
- Built the static Docusaurus site with Node 24 using node_modules/@docusaurus/core/bin/docusaurus.mjs build.
- Confirmed generated root and deep-link HTML include the redirect tags.